### PR TITLE
PAAS-380: not using en vars anymore to set unomi root password

### DIFF
--- a/scripts/reset-unomi-root-password.py
+++ b/scripts/reset-unomi-root-password.py
@@ -11,10 +11,10 @@ unomi_env_file = sys.argv[2]
 datadog_conf_file = sys.argv[3]
 
 pwd_set = False
-password_line = "UNOMI_ROOT_PASSWORD=" + new_password
+password_line = "export UNOMI_ROOT_PASSWORD=" + new_password
 with fileinput.FileInput(unomi_env_file, inplace=True) as file:
     for line in file:
-        if line.startswith('UNOMI_ROOT_PASSWORD'):
+        if "UNOMI_ROOT_PASSWORD" in line:
             line = password_line
             pwd_set = True
         print(line, end='')

--- a/unomi.yml
+++ b/unomi.yml
@@ -64,7 +64,6 @@ onBeforeInstall: |
     env: {
       PACKAGE_TYPE: '${globals.package_type}',
       UNOMI_VERSION: unomiVersion,
-      UNOMI_ROOT_PASSWORD: '${globals.unomi_root_password}',
       jahia_cfg_operatingMode: '${settings.mode}',
       envName: '${globals.envname}',
       UNOMI_HTTP_PORT: '80',
@@ -203,6 +202,7 @@ actions:
         else
           echo "export UNOMI_HAZELCAST_TCPIP_MEMBERS=${globals.unomi_IPs}" >> $envfile
         fi
+        echo "export UNOMI_ROOT_PASSWORD=${globals.unomi_root_password}" >> /opt/unomi/unomi-$STACK_VERSION/bin/setenv
 
   execdockrun:
     forEach(nodes.cp):


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-380

Short description:
 - not using en vars anymore to set unomi root password
 - Add export before var in setenv because it was not working at the first start (don't know why)