### PR TITLE
Paas 1140 -- Avoid updating indexes replicas number when redeploy jcustomer

### DIFF
--- a/unomi.yml
+++ b/unomi.yml
@@ -112,6 +112,7 @@ onInstall:
     vars: {"envName": "${env.envName}", "DATADOGAPIKEY": "${settings.ddogApikey}"}
   - setupES
   - setReplica
+  - updateReplica
   - setupUnomi
   - setupDatadogAgentUnomi: cp
   - setupDatadogAgentEs: es
@@ -144,12 +145,14 @@ onAfterServiceScaleOut[es]:
   - setSomeGlobals
   - setupES
   - setReplica
+  - updateReplica
   - setupDatadogAgentEs: es
 
 onAfterServiceScaleIn[es]:
   - setSomeGlobals
   - setupES
   - setReplica
+  - updateReplica
 
 # -- Actions --
 actions:
@@ -218,7 +221,6 @@ actions:
           echo "export ${globals.PRONAME}_ELASTICSEARCH_DEFAULTINDEX_REPLICAS=${globals.replica}" >> $setenv
           systemctl is-active --quiet karaf && systemctl restart karaf || exit 0
         user: root
-    - updateReplica
 
   updateHazelcast:
     - getUnomiIPs

--- a/unomi.yml
+++ b/unomi.yml
@@ -184,8 +184,10 @@ actions:
 
   updateReplica:
     - cmd[${nodes.es.first.id}]: |-
-        curl -s http://$(hostname):9200/_cat/shards | awk '{print $1}' | sort | uniq | while read index; do
-            curl -s -XPUT http://$(hostname):9200/$(echo $index)/_settings -d '{"index":{"number_of_replicas": ${globals.replica} }}'
+        curl -s http://$(hostname):9200/_cat/indices | awk -v repl=${globals.replica} '$6>repl {print $3}' | while read index; do
+            curl -s -XPUT http://$(hostname):9200/$index/_settings \
+              -H "Content-Type: application/json" \
+              -d '{"index":{"number_of_replicas": ${globals.replica} }}'
         done
 
   setReplica:

--- a/unomi.yml
+++ b/unomi.yml
@@ -187,7 +187,7 @@ actions:
 
   updateReplica:
     - cmd[${nodes.es.first.id}]: |-
-        curl -s http://$(hostname):9200/_cat/indices | awk -v repl=${globals.replica} '$6>repl {print $3}' | while read index; do
+        curl -s http://$(hostname):9200/_cat/indices | awk -v repl=${globals.replica} '$6!=repl {print $3}' | while read index; do
             curl -s -XPUT http://$(hostname):9200/$index/_settings \
               -H "Content-Type: application/json" \
               -d '{"index":{"number_of_replicas": ${globals.replica} }}'


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1140

Short description: Avoid updating indexes replicas number when redeploy jcustomer + better `updateReplica` action (more beautiful by acting only on needed indices and compatible with ES7) 
