### PR TITLE
PAAS-1230: remove useless action

### DIFF
--- a/unomi_update_dx.yml
+++ b/unomi_update_dx.yml
@@ -96,9 +96,6 @@ actions:
           fi
         done
         jcustomer_key=$(sudo cat /root/.secrets/jcustomer.key)
-        if [ "${this}" == "proc" ]; then
-          sed -i "s/#operatingMode/operatingMode/" $STACK_PATH/conf/digital-factory-config/jahia/jahia.properties
-        fi
         wget -qO /data/digital-factory-data/karaf/etc/${globals.module_conf_file} ${baseUrl}/common/${globals.module_conf_file}
         sed -i 's!\(\(mf\|jexperience\)\.\(unomi\|jCustomer\)URL= http://\).*!\1${globals.unomidns}!' /data/digital-factory-data/karaf/etc/${globals.module_conf_file}
         sed -i "s,^\# \(\(mf\|jexperience\)\.\(unomi\|jCustomer\)Key=\),\1${jcustomer_key}," /data/digital-factory-data/karaf/etc/${globals.module_conf_file}


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1230

Short description:
I don't get why proc should have **operatingMode** hardcoded and not CP nodes.
I tested to link a Jahia & jCustomer without that piece of code and it works properly.