### PR TITLE
PAAS-1301 move updateHazelcast from onBefore to onAfter for scales

### DIFF
--- a/unomi.yml
+++ b/unomi.yml
@@ -119,17 +119,21 @@ onInstall:
 
 onBeforeScaleIn[cp]:
   - saveUnomiRootPassword
+
+onAfterScaleIn[cp]:
+  - getUnomiRootPassword
   - setSomeGlobals
   - updateHazelcast
+  - forEach(event.response.nodes):
+      - setReplica
 
 onBeforeServiceScaleOut[cp]:
   - saveUnomiRootPassword
-  - setSomeGlobals
-  - updateHazelcast
 
 onAfterServiceScaleOut[cp]:
   - getUnomiRootPassword
   - setSomeGlobals
+  - updateHazelcast
   - forEach(event.response.nodes):
       - setReplica
   - setupDatadogAgentUnomi: cp

--- a/update.yml
+++ b/update.yml
@@ -23,17 +23,21 @@ onUninstall:
 
 onBeforeScaleIn[cp]:
   - saveUnomiRootPassword
+
+onAfterScaleIn[cp]:
+  - getUnomiRootPassword
   - setSomeGlobals
   - updateHazelcast
+  - forEach(event.response.nodes):
+      - setReplica
 
 onBeforeServiceScaleOut[cp]:
   - saveUnomiRootPassword
-  - setSomeGlobals
-  - updateHazelcast
 
 onAfterServiceScaleOut[cp]:
   - getUnomiRootPassword
   - setSomeGlobals
+  - updateHazelcast
   - forEach(event.response.nodes):
       - setReplica
   - setupDatadogAgentUnomi: cp


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1301

Short description:
don't make sens to update hazelcast before new nodes are up
when scaling from 1 nodes to 3, here is what happen:
```
 for node in 28645 28648 28649; do ssh ${node}-110@gate.dev.j.jahia.com "grep HAZELCAST_TCPIP_MEMBERS /opt/jcustomer/jcustomer/bin/setenv"; done                     
export UNOMI_HAZELCAST_TCPIP_MEMBERS=172.21.2.57,172.21.2.161,172.21.2.55
export UNOMI_HAZELCAST_TCPIP_MEMBERS=172.21.2.57
export UNOMI_HAZELCAST_TCPIP_MEMBERS=172.21.2.57
```
(where `28645` is the first node and `172.21.2.57` his ip)
