### PR TITLE
PAAS-1309 revert to HOSTNAME in dd agent's ES integration conf

### DIFF
--- a/unomi.yml
+++ b/unomi.yml
@@ -340,10 +340,9 @@ actions:
 
   setupDatadogAgentEs:
     cmd[${this}]: |-
-      NODE_HOSTNAME=$(echo "${@i.url}" | sed 's/^https:\/\///')
       chmod 755 /var/log/elasticsearch/
       chmod 755 /var/log/elasticsearch/*.log -R
-      sed -i "s/\(url: http:\/\/\).*\(:.*\)/\1${NODE_HOSTNAME}\2/" /etc/datadog-agent/conf.d/elastic.d/conf.yaml
+      sed -i "s/\(url: http:\/\/\).*\(:.*\)/\1${HOSTNAME}\2/" /etc/datadog-agent/conf.d/elastic.d/conf.yaml
       sed -i "s/\(env:\).*\('\)/\1${PACKAGE_TYPE}\2/" /etc/datadog-agent/conf.d/elastic.d/conf.yaml
       mkdir /etc/datadog-agent/conf.d/jelastic.d /var/log/jelastic-packages
       chown root:root /var/log/jelastic-packages

--- a/update.yml
+++ b/update.yml
@@ -246,7 +246,7 @@ actions:
     cmd[${this}]: |-
       chmod 755 /var/log/elasticsearch/
       chmod 755 /var/log/elasticsearch/*.log -R
-      sed -i 's/\(url: http:\/\/\).*\(:.*\)/\1es\2/' /etc/datadog-agent/conf.d/elastic.d/conf.yaml
+      sed -i "s/\(url: http:\/\/\).*\(:.*\)/\1${HOSTNAME}\2/" /etc/datadog-agent/conf.d/elastic.d/conf.yaml
       sed -i "s/\(env:\).*\('\)/\1${PACKAGE_TYPE}\2/" /etc/datadog-agent/conf.d/elastic.d/conf.yaml
       mkdir /etc/datadog-agent/conf.d/jelastic.d /var/log/jelastic-packages
       chown root:root /var/log/jelastic-packages


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1309

Short description: fix silly use of `es` name for dd agent check, also update `unomi.yml` which was not aligned to changes
